### PR TITLE
change box from chef/centos6.5 to bento/centos6.7

### DIFF
--- a/handson/Vagrantfile
+++ b/handson/Vagrantfile
@@ -11,7 +11,7 @@ IP2 = "192.168.200.20"
 IP3 = "192.168.200.30"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "chef/centos-6.5"
+  config.vm.box = "bento/centos-6.7"
 
   config.vm.define "#{HOSTNAME1}" do |guest|
     guest.vm.provision "shell", path: "ansible.sh"

--- a/localdev/Vagrantfile
+++ b/localdev/Vagrantfile
@@ -7,7 +7,7 @@ HOSTNAME1 = "ansible-local-dev"
 IP1 = "192.168.200.40"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "chef/centos-6.5"
+  config.vm.box = "bento/centos-6.7"
 
   config.vm.define "#{HOSTNAME1}" do |guest|
     guest.vm.provision "shell", path: "ansible_local.sh"


### PR DESCRIPTION
vagrant box chef/centos6.5 is deprecated.
change box from chef/centos6.5 to bento/centos6.7
